### PR TITLE
Fixing dependencies, golang migrated from hg to github.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,7 +2,7 @@
 github.com/armon/consul-api  0e644b80dc2054cd4edbfa7a273b87f37fc120a1
 github.com/jessevdk/go-flags 37e89eb6730ccfebfa05c17940954e4308719317
 github.com/Sirupsen/logrus   f9e0c0dd4aec8f179cb6dc4f2aea811f36b58f54
-github.com/amir/raidman      e5c0381f4e85217ed2e4fdee2d8d8c5f8e101c0e
+github.com/amir/raidman      57b78a08c96234a4cf19a7c33c8eb28ce4214cbc
 
 ## test
 github.com/onsi/ginkgo/ginkgo 90d6a472e25d8096739d5405286ec051c87fade7
@@ -12,13 +12,8 @@ github.com/stretchr/testify   de7fcff264cd05cc0c90c509ea789a436a0dd206
 ## test codegen
 github.com/vektra/mockery 5e98d9a4390b6c1c9b9f7d326f438b5c3d01a7fc
 
-### transitive deps
-## required by raidman
-code.google.com/p/goprotobuf/proto 36be16571e14
-
 ## required by mockery, I think
 github.com/vektra/errors           c64d83aba85aa4392895aadeefabbd24e89f3580
-code.google.com/p/go.tools/imports 7a99b946364f
 
 ## required by testify, I think
 github.com/stretchr/objx cbeaeb16a013161a98496fad62933b1d21786672


### PR DESCRIPTION
- Broken transitive dependencies removed. They appear to be pulled along with the dependencies when the pull occurs.

A newer version of http://www.github.com/amir/raimdman pulls the updated dependencies.

This at least gets things back into being able to spit out a usable binary.
